### PR TITLE
Support psr/container ^2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     "require": {
         "php": ">=8.0",
         "kelunik/fiber-local": "^1-dev",
-        "psr/container": "^1.1"
+        "psr/container": "^1.1 | ^2"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5.2",


### PR DESCRIPTION
The only difference I see between psr/container ^1.x and 2.x is the return type `bool` on ContainerInterface, which seems already implemented by the injector's container like that.