### PR TITLE
Adjust types due to php 8.1 deprecations

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -17,7 +17,7 @@ interface Container extends ContainerInterface, \IteratorAggregate
     public function has(string $id): bool;
 
     /** @return iterable<Provider> */
-    public function getIterator(): iterable;
+    public function getIterator(): \Traversable;
 
     public function getProvider(string $id): Provider;
 }

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -32,7 +32,7 @@ final class Definitions implements \IteratorAggregate
     /**
      * @return iterable<Definition>
      */
-    public function getIterator(): iterable
+    public function getIterator(): \Generator
     {
         foreach ($this->definitions as $id => $definition) {
             yield $id => $definition;

--- a/src/RootContainer.php
+++ b/src/RootContainer.php
@@ -33,7 +33,7 @@ final class RootContainer implements Container
         return isset($this->providers[$id]);
     }
 
-    public function getIterator(): iterable
+    public function getIterator(): \Generator
     {
         foreach ($this->providers as $id => $provider) {
             yield (string) $id => $provider;


### PR DESCRIPTION
Running the tests on php 8.1 gives deprecations like so

```
$ ./vendor/bin/phpunit test
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

PHP Deprecated:  Return type of Amp\Injector\Definitions::getIterator(): iterable should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /amphp/injector/src/Definitions.php on line 35
.
Deprecated: Return type of Amp\Injector\Definitions::getIterator(): iterable should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /amphp/injector/src/Definitions.php on line 35
......PHP Deprecated:  Return type of Amp\Injector\Container::getIterator(): iterable should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /amphp/injector/src/Container.php on line 20
.
Deprecated: Return type of Amp\Injector\Container::getIterator(): iterable should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /amphp/injector/src/Container.php on line 20
............................                              36 / 36 (100%)

Time: 00:00.268, Memory: 6.00 MB

OK (36 tests, 59 assertions)
```

---

If you want to keep return type as `iterable` maybe with a new method?